### PR TITLE
chore: turn off firebase access for now

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -10,7 +10,7 @@ service cloud.firestore {
       // Make sure to write security rules for your app before that time, or
       // else all client requests to your database will be denied until you
       // update your rules.
-      allow read, write: if request.time < timestamp.date(2024, 10, 18);
+      allow read, write: false;
     }
   }
 }


### PR DESCRIPTION
I'm assuming that cloudrun will still have access because of the terraform iam stuff that we have. But I'm not sure.